### PR TITLE
Manifest V3 fixes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
     "128": "icons/icon128.png"
   },
   "background": {
+    "scripts": ["js/background.js"],
     "service_worker": "js/background.js"
   },
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -10,9 +10,7 @@
     "128": "icons/icon128.png"
   },
   "background": {
-    "scripts": [
-      "js/background.js"
-    ]
+    "service_worker": "js/background.js"
   },
   "permissions": [
     "activeTab",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "npm run eslint && npm run build-chrome && npm run build-firefox && npm run build-edge && npm run build-safari",
     "build-chrome": "cross-env KW_BROWSER=chrome webpack --mode=production",
-    "build-firefox": "cross-env KW_BROWSER=firefox webpack --mode=production",
+    "build-firefox": "cross-env KW_BROWSER=firefox webpack --mode=production && npx web-ext build -o -s dist/firefox",
     "build-edge": "cross-env KW_BROWSER=edge webpack --mode=production",
     "build-safari": "cross-env KW_BROWSER=safari webpack --mode=production",
     "watch-chrome": "cross-env KW_BROWSER=chrome webpack --mode=development --watch",

--- a/src/background/backend.ts
+++ b/src/background/backend.ts
@@ -183,7 +183,7 @@ class Backend extends TypedEmitter<BackendEvents> {
 
     private request(request: KeeWebConnectRequest): Promise<KeeWebConnectResponse> {
         return new Promise((resolve, reject) => {
-            const timeout = window.setTimeout(() => {
+            const timeout = self.setTimeout(() => {
                 this._currentRequest = undefined;
                 const errStr = chrome.i18n.getMessage('errorRequestTimeout');
                 reject(new Error(errStr));


### PR DESCRIPTION
Fixes left to do after merging #61 

- [x] Replace "background.scripts" with "background.service_worker" in the manifest.json for Chrome (we need to keep it for Firefox so we'll have to put up with the Chrome warning).
- [x] Connect error ReferenceError: window is not defined. Context: js/background.js