### PR TITLE
Fix Google Chrome Manifest v3 compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
     "contextMenus",
     "storage",
     "nativeMessaging",
-    "webNavigation"
+    "webNavigation",
+    "scripting"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/src/background/protocol/protocol-impl.ts
+++ b/src/background/protocol/protocol-impl.ts
@@ -56,7 +56,10 @@ class ProtocolImpl {
     }
 
     private makeEncryptedRequest(payload: KeeWebConnectRequest): KeeWebConnectEncryptedRequest {
-        if (window.logDecryptedPayload) {
+        if (
+            (typeof window !== 'undefined' && window.logDecryptedPayload) ||
+            (typeof self !== 'undefined' && self.logDecryptedPayload)
+        ) {
             // eslint-disable-next-line no-console
             console.log('Request payload', payload);
         }
@@ -117,7 +120,10 @@ class ProtocolImpl {
         const json = new TextDecoder().decode(data);
         const payload = <KeeWebConnectEncryptedResponse>JSON.parse(json);
 
-        if (window.logDecryptedPayload) {
+        if (
+            (typeof window !== 'undefined' && window.logDecryptedPayload) ||
+            (typeof self !== 'undefined' && self.logDecryptedPayload)
+        ) {
             // eslint-disable-next-line no-console
             console.log('Response payload', payload);
         }


### PR DESCRIPTION
The built `background.js` script contained few left over instances of window global, which is not declared in service workers. On Chrome and other Chromium based browsers that end up using the service worker variation, will fail on a fatal error due to this.

This PR changes so that the combined "service worker / background script" checks whether the debugging flag exits either in the self or the window global in a graceful manner, accounting for either or being undeclared.

Also adds missing `scripting` permission to the manifest. In Chrome, the used `chrome.scripting.executeScript` function is only available when the extension has scripting permissions. Without it, filling form fields will not function.