### PR TITLE
Remove deprecated `background.scripts` in manifest file.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,6 @@
     "128": "icons/icon128.png"
   },
   "background": {
-    "scripts": ["js/background.js"],
     "service_worker": "js/background.js"
   },
   "permissions": [


### PR DESCRIPTION
Remove this error:
```
'background.scripts' requires manifest version of 2 or lower.
```